### PR TITLE
Remove leading slash from repo name in ssh handler

### DIFF
--- a/git_command.go
+++ b/git_command.go
@@ -3,6 +3,7 @@ package gitkit
 import (
 	"fmt"
 	"regexp"
+	"strings"
 )
 
 var gitCommandRegex = regexp.MustCompile(`^(git[-|\s]upload-pack|git[-|\s]upload-archive|git[-|\s]receive-pack) '(.*)'$`)
@@ -22,7 +23,7 @@ func ParseGitCommand(cmd string) (*GitCommand, error) {
 	result := &GitCommand{
 		Original: cmd,
 		Command:  matches[0][1],
-		Repo:     matches[0][2],
+		Repo:     strings.Replace(matches[0][2], "/", "", 1),
 	}
 
 	return result, nil

--- a/git_command_test.go
+++ b/git_command_test.go
@@ -10,6 +10,7 @@ func TestParseGitCommand(t *testing.T) {
 	examples := map[string]GitCommand{
 		"git-upload-pack 'hello.git'":    GitCommand{"git-upload-pack", "hello.git", "git-upload-pack 'hello.git'"},
 		"git upload-pack 'hello.git'":    GitCommand{"git upload-pack", "hello.git", "git upload-pack 'hello.git'"},
+		"git-upload-pack '/hello.git'":   GitCommand{"git-upload-pack", "hello.git", "git-upload-pack 'hello.git'"},
 		"git-receive-pack 'hello.git'":   GitCommand{"git-receive-pack", "hello.git", "git-receive-pack 'hello.git'"},
 		"git receive-pack 'hello.git'":   GitCommand{"git receive-pack", "hello.git", "git receive-pack 'hello.git'"},
 		"git-upload-archive 'hello.git'": GitCommand{"git-upload-archive", "hello.git", "git-upload-archive 'hello.git'"},

--- a/git_command_test.go
+++ b/git_command_test.go
@@ -8,13 +8,14 @@ import (
 
 func TestParseGitCommand(t *testing.T) {
 	examples := map[string]GitCommand{
-		"git-upload-pack 'hello.git'":    GitCommand{"git-upload-pack", "hello.git", "git-upload-pack 'hello.git'"},
-		"git upload-pack 'hello.git'":    GitCommand{"git upload-pack", "hello.git", "git upload-pack 'hello.git'"},
-		"git-upload-pack '/hello.git'":   GitCommand{"git-upload-pack", "hello.git", "git-upload-pack 'hello.git'"},
-		"git-receive-pack 'hello.git'":   GitCommand{"git-receive-pack", "hello.git", "git-receive-pack 'hello.git'"},
-		"git receive-pack 'hello.git'":   GitCommand{"git receive-pack", "hello.git", "git receive-pack 'hello.git'"},
-		"git-upload-archive 'hello.git'": GitCommand{"git-upload-archive", "hello.git", "git-upload-archive 'hello.git'"},
-		"git upload-archive 'hello.git'": GitCommand{"git upload-archive", "hello.git", "git upload-archive 'hello.git'"},
+		"git-upload-pack 'hello.git'":        GitCommand{"git-upload-pack", "hello.git", "git-upload-pack 'hello.git'"},
+		"git upload-pack 'hello.git'":        GitCommand{"git upload-pack", "hello.git", "git upload-pack 'hello.git'"},
+		"git-upload-pack '/hello.git'":       GitCommand{"git-upload-pack", "hello.git", "git-upload-pack 'hello.git'"},
+		"git-upload-pack '/hello/world.git'": GitCommand{"git-upload-pack", "hello/world.git", "git-upload-pack 'hello.git'"},
+		"git-receive-pack 'hello.git'":       GitCommand{"git-receive-pack", "hello.git", "git-receive-pack 'hello.git'"},
+		"git receive-pack 'hello.git'":       GitCommand{"git receive-pack", "hello.git", "git receive-pack 'hello.git'"},
+		"git-upload-archive 'hello.git'":     GitCommand{"git-upload-archive", "hello.git", "git-upload-archive 'hello.git'"},
+		"git upload-archive 'hello.git'":     GitCommand{"git upload-archive", "hello.git", "git upload-archive 'hello.git'"},
 	}
 
 	for s, expected := range examples {


### PR DESCRIPTION
Should fix issues when git remote is in `ssh://git@localhost:2222/a/b/c.git` format