### PR TITLE
Add optional error message on authentication fail

### DIFF
--- a/http.go
+++ b/http.go
@@ -22,7 +22,7 @@ type service struct {
 type Server struct {
 	config   Config
 	services []service
-	AuthFunc func(Credential, *Request) (bool, error)
+	AuthFunc func(Credential, *Request) (bool, string, error)
 }
 
 type Request struct {
@@ -103,7 +103,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		allow, err := s.AuthFunc(cred, req)
+		allow, msg, err := s.AuthFunc(cred, req)
 		if !allow || err != nil {
 			if err != nil {
 				logError("auth", err)
@@ -111,6 +111,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 			logError("auth", fmt.Errorf("rejected user %s", cred.Username))
 			w.WriteHeader(http.StatusUnauthorized)
+			if msg != "" {
+				w.Write([]byte(msg))
+			}
 			return
 		}
 	}


### PR DESCRIPTION
I wanted to return a message to the user when HTTP authentication failed very much like Heroku does (https://devcenter.heroku.com/articles/git#http-git-authentication).

I added a third value to the AuthFunc interface if not empty it gets written to the response.