### PR TITLE
fix panic if hooks are not passed

### DIFF
--- a/config.go
+++ b/config.go
@@ -72,7 +72,7 @@ func (c *Config) Setup() error {
 		}
 	}
 
-	if c.AutoHooks == true {
+	if c.AutoHooks && c.Hooks != nil {
 		return c.setupHooks()
 	}
 

--- a/ssh.go
+++ b/ssh.go
@@ -137,7 +137,7 @@ func (s *SSH) handleConnection(keyID string, chans <-chan ssh.NewChannel) {
 						return
 					}
 
-					if !repoExists(filepath.Join(s.config.Dir, gitcmd.Repo)) && s.config.AutoCreate == true {
+					if !repoExists(filepath.Join(s.config.Dir, gitcmd.Repo)) && s.config.AutoCreate {
 						err := initRepo(gitcmd.Repo, s.config)
 						if err != nil {
 							logError("repo-init", err)


### PR DESCRIPTION
Fixes:
```
 go run .
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x8 pc=0x100a26f90]

goroutine 1 [running]:
github.com/sosedoff/gitkit.(*HookScripts).setupInDir(0x0, {0x1400009a5a0?, 0x140000b8ea0?})
        /Users/nikita/go/pkg/mod/github.com/sosedoff/gitkit@v0.4.0/config.go:31 +0xb0
github.com/sosedoff/gitkit.(*Config).setupHooks(0x140000f0180)
        /Users/nikita/go/pkg/mod/github.com/sosedoff/gitkit@v0.4.0/config.go:95 +0xec
github.com/sosedoff/gitkit.(*Config).Setup(0x140000f0180)
        /Users/nikita/go/pkg/mod/github.com/sosedoff/gitkit@v0.4.0/config.go:76 +0x58
github.com/sosedoff/gitkit.(*Server).Setup(...)
        /Users/nikita/go/pkg/mod/github.com/sosedoff/gitkit@v0.4.0/http.go:224
main.main()
        /Users/nikita/projects/gitkit-test/main.go:7 +0x330
exit status 2
```

Code:
```go
package main

import "github.com/sosedoff/gitkit"

func main() {
	server := gitkit.New(gitkit.Config{AutoHooks: true, Dir: "test"})
	server.Setup()
}
```